### PR TITLE
Add check for AppController pushing the first link to the chain

### DIFF
--- a/server/__tests__/domain/AppController.spec.ts
+++ b/server/__tests__/domain/AppController.spec.ts
@@ -40,6 +40,10 @@ describe("AppController", () => {
                 minSats,
                 "expect minSats to be called with the provided argument",
             );
+            expect(sut.chainTip).to.equal(
+                fakeLink,
+                "expect chainTip to equal first link",
+            );
         });
 
         it("syncs the invoice database", async () => {


### PR DESCRIPTION
Minor change to the `AppController.start()` test.

I noticed after completing the exercises (and passing all of the tests), my app wasn't running properly. I had forgotten to add the first link to the chain, which I soon realized after my frontend had no initial message for me to sign. I think it might be helpful to catch this in the test!

Did a basic test for this test against my before/after [solution](https://github.com/alecchendev/ln-coding-practical/blob/main/building-lightning-invoices/server/src/domain/AppController.ts#L32) and it seems to work:

Example failing:
![image](https://user-images.githubusercontent.com/30279834/200479262-53a8103d-a561-458d-9a99-cb20c03a1809.png)


