### PR TITLE
Upgrade types/node dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@types/node": "^17.0.23"
+    "@types/node": "^20.2.1"
   }
 }


### PR DESCRIPTION
The current old version might result in this error happening:
```
Error TS2403: Subsequent variable declarations must have the same type. 
Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }',
but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.
```